### PR TITLE
Solved a very obscure bug where after skipping a "/" and goingUp a no…

### DIFF
--- a/xml/xml/XMLDoc.cpp
+++ b/xml/xml/XMLDoc.cpp
@@ -31,7 +31,7 @@ void XMLDoc::parse()
 		//conditii pt extragerea atributelor si valorilor lor
 		if (nameEnded && c != '>')
 		{
-			if (!atribEnded)
+			if (!atribEnded && c != ' ')
 				atrib += c;
 			curm = fin.peek();
 			if (curm == '=')
@@ -42,16 +42,12 @@ void XMLDoc::parse()
 			if (!valueEnded)
 			{
 				fin >> c;
-				if (c != '"')
-				{
-					valatrib += c; fin >> c;
-				}
 				while (c != '"')
 				{
 					valatrib += c; fin >> c;
 				}
 				tree.addAttrib(atrib, valatrib);
-				atrib.clear(); valatrib = "";
+				atrib.clear(); valatrib.clear();
 				valueEnded = true; atribEnded = false;
 			}
 		}
@@ -79,12 +75,13 @@ void XMLDoc::parse()
 			if (firstNod)
 			{
 				tree.init(); firstNod = false;
+				parse();
 			}
 			else if (canInsert)
 			{
 				tree.insert(); tree.goDownLast();
+				parse();
 			}
-			parse();
 		}
 	}
 }
@@ -92,11 +89,12 @@ void XMLDoc::read() {
 	fin.open(docReadName);
 	fin >> noskipws;
 	if (!fin.is_open())
-		cout << "Eroare la deschidere fisier";
+		cout << "Error while trying to open file";
 	else
 	{
 		checkVer(); parse();
 	}
+	tree.displayTree();
 	fin.close();
 }
 
@@ -125,12 +123,10 @@ void XMLDoc::createLine(int depth) {
 	line += "<" + tree.getName();
 	for (int i = 0; i < tree.getAttribNr(); i++)
 	{
-		if (i == 0)
-			line += " ";
-		line += tree.getAttrib(i) + "=" + "\"" + tree.getAttribValue(i) + "\"";
+		line += " " + tree.getAttrib(i) + "=" + "\"" + tree.getAttribValue(i) + "\"";
 	}
 	if (tree.getChildrenNr() == 0) {
-		line += " />";
+		line += "/>";
 		fout << line << endl;;
 	}
 	else {

--- a/xml/xml/XMLDoc.cpp
+++ b/xml/xml/XMLDoc.cpp
@@ -94,7 +94,6 @@ void XMLDoc::read() {
 	{
 		checkVer(); parse();
 	}
-	tree.displayTree();
 	fin.close();
 }
 
@@ -110,9 +109,6 @@ void XMLDoc::setDocReadName(const string s) {
 void XMLDoc::setDocSaveName(const string s) {
 	docSaveName = s;
 }
-
-
-
 
 void XMLDoc::createLine(int depth) {
 	string line;
@@ -157,7 +153,6 @@ void XMLDoc::save() {
 
 void XMLDoc::recsearch(string x, bool & p)
 {
-	int i;
 	if (p == true)
 	{
 		if (tree.getName() == x)
@@ -165,7 +160,7 @@ void XMLDoc::recsearch(string x, bool & p)
 			p = false;
 			return;
 		}
-		for (i = 0; i<tree.getChildrenNr(); i++)
+		for (int i = 0; i<tree.getChildrenNr(); i++)
 		{
 			tree.goDown(i);
 			recsearch(x, p);
@@ -173,7 +168,6 @@ void XMLDoc::recsearch(string x, bool & p)
 				tree.goUp(1);
 		}
 	}
-
 }
 
 void XMLDoc::gotonode(string x)
@@ -185,10 +179,8 @@ void XMLDoc::gotonode(string x)
 
 void XMLDoc::addNode(string nod, string name)
 {
-	gotonode(nod);
-	tree.insert();
-	tree.goDownLast();
-	tree.replaceName(name);
+	gotonode(nod); tree.insert();
+	tree.goDownLast(); tree.replaceName(name);
 }
 
 void XMLDoc::addAtribut(string nod, string atribut, string valatribut)
@@ -201,13 +193,9 @@ void XMLDoc::deleteNode(string nod, string All_or_Current)
 {
 	gotonode(nod);
 	if (All_or_Current == "All")
-	{
 		tree.deleteCurr();
-	}
 	else if (All_or_Current == "Current")
-	{
 		tree.deleteOnlyCurr();
-	}
 }
 
 void XMLDoc::gotoRoot()
@@ -217,49 +205,38 @@ void XMLDoc::gotoRoot()
 
 void XMLDoc::Parcurgere()
 {
-	int i, j;
-	for (i = 0; i<tree.getChildrenNr(); i++)
+	for (int i = 0; i<tree.getChildrenNr(); i++)
 	{
 		tree.goDown(i);
-		for (j = 0; j < tree.getNivel(); j++)
-		{
+		for (int j = 0; j < tree.getNivel(); j++)
 			cout << "\t";
-		}
 		cout << tree.getNivel() << " ";
-		ShowName();
-		ShowAttrib();
-		cout << endl;
-		Parcurgere();
+		ShowName(); ShowAttrib();
+		cout << endl; Parcurgere();
 		tree.goUp(1);
 	}
 }
 
 void XMLDoc::displayTree()
 {
-	gotoRoot();
-	ShowName();
-	ShowAttrib();
-	Parcurgere();
+	gotoRoot(); ShowName();
+	ShowAttrib(); Parcurgere();
  }
 
-void XMLDoc::delAtribut(string x)
+void XMLDoc::delAtribut(string node, string attrib)
 {
-	tree.deleteAttrib(x);
+	gotonode(node);
+	tree.deleteAttrib(attrib);
 }
-
 
 string XMLDoc::ShowName()
 {
 	cout << tree.getName() << endl;
 	return tree.getName();
-
 }
 
 void XMLDoc::ShowAttrib()
 {
-	int i;
-	for (i = 0; i < tree.getAttribNr(); i++)
-	{
+	for (int i = 0; i < tree.getAttribNr(); i++)
 		cout << " " << tree.getAttrib(i) << "=" << tree.getAttribValue(i);
-	}
 }

--- a/xml/xml/XMLDoc.h
+++ b/xml/xml/XMLDoc.h
@@ -21,20 +21,20 @@ class XMLDoc {
 	void checkVer();
 	void parse();
 	void createLine(int depth);
+	void recsearch(string x, bool & p);
+	void Parcurgere();
 public:
 	XMLDoc(const string docReadName = " ", const string docSaveName = " ");
 	void read();
 	void save();
 
 	void gotonode(string x);
-	void recsearch(string x, bool & p);
 	void addNode(string nod, string name);
 	void addAtribut(string nod, string atribut, string valatribut);
 	void deleteNode(string nod, string All_or_Current);
-	void delAtribut(string x);
+	void delAtribut(string node, string attrib);
 	void gotoRoot();
 	void displayTree();
-	void Parcurgere();
 	void ShowAttrib();
 	string ShowName();
 	        


### PR DESCRIPTION
…de, parse would be called again and if there was a white-space the name of the current node would be overwritten to null.
Also solved a bug which caused a white-space to be picked up in the attribute string, which caused the createline function to need a tweak.